### PR TITLE
fix: Paint the ambient light instead of blurring it

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -75,9 +75,11 @@ export default async function SlugPage({params}: Props) {
       <div aria-hidden="true" className="pointer-events-none fixed inset-0 overflow-hidden">
         {/* Ellipses, not circles: they give the slow turn something to show, and
             three long axes crossing at different rates never repeat a shape. */}
-        <div className="scene-light scene-light-a -top-[24%] left-[2%] h-[46vmax] w-[64vmax] bg-[#1b3fb5] opacity-[0.20]" />
-        <div className="scene-light scene-light-b top-[26%] -right-[18%] h-[56vmax] w-[44vmax] bg-[#5b2bc9] opacity-[0.16]" />
-        <div className="scene-light scene-light-c -bottom-[28%] left-[16%] h-[40vmax] w-[58vmax] bg-[#0f6f8c] opacity-[0.13]" />
+        {/* The colour is the text colour: the glow is a gradient of
+            `currentColor`, not a fill — see `.scene-light` in app.css. */}
+        <div className="scene-light scene-light-a -top-[24%] left-[2%] h-[46vmax] w-[64vmax] text-[#1b3fb5] opacity-[0.20]" />
+        <div className="scene-light scene-light-b top-[26%] -right-[18%] h-[56vmax] w-[44vmax] text-[#5b2bc9] opacity-[0.16]" />
+        <div className="scene-light scene-light-c -bottom-[28%] left-[16%] h-[40vmax] w-[58vmax] text-[#0f6f8c] opacity-[0.13]" />
         <div className="scene-grain absolute inset-0 opacity-[0.05]" />
         {/* Pulled down behind the card so the copy keeps its contrast, and down
             again at the edges — the light ends up pooling around the card. */}
@@ -88,13 +90,11 @@ export default async function SlugPage({params}: Props) {
           desktop, the bottom of the screen on a phone — so crossing over only
           turns the arrows round. */}
       <CardCollapseLink />
-      {/* Padding on the outside, the width cap on the inside: the card has to
-          come out the exact size and place it is in the modal — same `py-10`,
-          same 512, same margin under it on a phone — or the shared element
-          scales its own text mid-flight and every line ghosts. That margin is
-          also what keeps the last property clear of the pill down there. */}
-      <div className="relative flex min-h-full w-full justify-center px-3 py-10 md:px-4">
-        <div className="mb-[56px] flex w-full max-w-[512px] flex-col justify-center md:mb-0">
+      {/* Laid out like the CV: one column on the ambient, started below the top
+          edge rather than centred in the screen, so a long shot and a short one
+          both begin in the same place. */}
+      <div className="relative flex min-h-full w-full justify-center px-5 pt-[116px]">
+        <div className="flex w-full max-w-[512px] flex-col">
           <ShotDetail
             title={entry.title}
             image={entry.image}
@@ -103,6 +103,8 @@ export default async function SlugPage({params}: Props) {
             videos={entry.videos}
             size={entry.size}
           />
+          {/* Keeps the last property clear of the pill on the bottom edge. */}
+          <div className="flex h-[116px] w-full flex-shrink-0" />
         </div>
       </div>
     </main>

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -258,56 +258,25 @@ body {
 /* ---------------------------------------------------------------------------
    Shot modal → /[slug] detail — shared-element morph
 
-   The card and its artwork carry matching view-transition names on both pages,
-   so the browser hands us one group per pair and animates the box between the
-   two positions. Timings borrow the iOS sheet curve: quick to leave, long to
-   settle.
+   The artwork carries the same view-transition name on both pages, so the
+   browser hands us one group for the pair and animates the box between the two
+   positions. Everything around it — the card on the grid, the page it lands on
+   — is left to the root cross-fade, since the page wears no card of its own for
+   a card to morph into. Timings borrow the iOS sheet curve: quick to leave,
+   long to settle.
 --------------------------------------------------------------------------- */
 
-::view-transition-group(shot-card),
 ::view-transition-group(shot-media),
-::view-transition-old(shot-card),
-::view-transition-new(shot-card),
 ::view-transition-old(shot-media),
 ::view-transition-new(shot-media) {
   animation-duration: 440ms;
   animation-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
 }
 
-/* The card is glass — no background of its own, just `backdrop-filter`. A
-   captured element is painted in isolation with nothing behind it to sample, so
-   the blur resolves to nothing and the card comes out of the snapshot as a hole
-   with only its text and border in it. Mid-transition the cross-fading page
-   shows straight through that hole, brightest wherever the grid behind happens
-   to be bright, which reads as a grey band around the artwork.
-
-   So the glass is rebuilt one level up. The group box is a real box, exactly
-   the card at every frame, and what sits behind it in the transition layer is
-   the `root` snapshot — which still holds the grid and the backdrop, since only
-   the card's own painting was lifted out of it. Blurring that gives the same
-   frosted result the live card produces, at both ends and everywhere between,
-   instead of a flat colour guessing at it. A guess could not work anyway: the
-   glass takes its colour from whatever the camera happens to be parked over.
-
-   No `animation` here — the group's is the browser's, and it carries the morph. */
-::view-transition-group(shot-card) {
-  border-radius: 44px;
-  -webkit-backdrop-filter: blur(var(--card-blur));
-  backdrop-filter: blur(var(--card-blur));
-}
-
-@media (width >= 768px) {
-  ::view-transition-group(shot-card) {
-    border-radius: 52px;
-  }
-}
-
 /* Snapshots are replaced elements sized to the box they were captured from, so
-   they stretch if the group resizes. Both sides render the card at the same
-   width, so this only has to cover the odd viewport where they differ by a
-   pixel — cropping there beats squashing every line of text. */
-::view-transition-old(shot-card),
-::view-transition-new(shot-card),
+   they stretch if the group resizes. The artwork is the same width on both
+   sides, so this only has to cover the odd viewport where they differ by a
+   pixel — cropping there beats squashing the picture. */
 ::view-transition-old(shot-media),
 ::view-transition-new(shot-media) {
   width: 100%;
@@ -451,24 +420,41 @@ body:has([data-smooth-scroll]) {
     #050607;
 }
 
-/* Ambient glow bleeding out from under the card — graphite, not chromatic. */
+/* Ambient glow bleeding out from under the card — graphite, not chromatic.
+   Three ramps rather than three shapes under a blur: the card tilts and scales
+   under the pointer, and a filtered layer has to be re-rasterised every frame
+   it does, which is what made arriving on this page stutter on a phone. The
+   stops carry the softness the blur used to, and the element is sized for the
+   spread the blur used to give it. */
 .ico-halo {
-  border-radius: 40px;
+  /* Every ellipse has to die out inside the box — a blur had no edge to run
+     into, a gradient does, and one that still carries colour where the element
+     stops draws the element as a rectangle. Radius never exceeds the distance
+     from its own centre to the nearest side. */
   background:
-    radial-gradient(60% 55% at 26% 18%, rgba(158, 176, 200, 0.22) 0%, transparent 70%),
-    radial-gradient(55% 55% at 82% 30%, rgba(126, 136, 154, 0.18) 0%, transparent 72%),
-    radial-gradient(60% 60% at 50% 92%, rgba(96, 106, 120, 0.14) 0%, transparent 72%);
-  filter: blur(56px);
+    radial-gradient(36% 32% at 38% 34%, rgba(158, 176, 200, 0.22) 0%, rgba(158, 176, 200, 0.08) 46%, transparent 100%),
+    radial-gradient(32% 32% at 66% 42%, rgba(126, 136, 154, 0.18) 0%, rgba(126, 136, 154, 0.06) 48%, transparent 100%),
+    radial-gradient(36% 28% at 52% 70%, rgba(96, 106, 120, 0.15) 0%, rgba(96, 106, 120, 0.05) 48%, transparent 100%);
   opacity: calc(0.5 + var(--glare) * 0.5);
   transition: opacity 0.7s ease-out;
 }
 
-/* Light pooling on the plate — greyscale, so the black never picks up a hue. */
+/* Light pooling on the plate — greyscale, so the black never picks up a hue.
+   Same story as the halo, and the morphing border-radius goes with the blur:
+   under 46px of it the shape was never legible anyway, and animating a radius
+   costs a repaint of the layer on every frame. The drift is what read as
+   organic, and the drift stays. */
 .ico-blob {
-  filter: blur(46px);
+  background-image: radial-gradient(
+    closest-side,
+    currentColor 0%,
+    color-mix(in srgb, currentColor 66%, transparent) 44%,
+    color-mix(in srgb, currentColor 24%, transparent) 72%,
+    transparent 100%
+  );
   mix-blend-mode: screen;
   opacity: 0.16;
-  will-change: transform, border-radius;
+  will-change: transform;
 }
 
 .ico-blob-a {
@@ -579,15 +565,12 @@ body:has([data-smooth-scroll]) {
 @keyframes ico-blob-a {
   0%,
   100% {
-    border-radius: 58% 42% 47% 53% / 52% 45% 55% 48%;
     transform: translate3d(calc(var(--shift) * 14px), 0, 0) rotate(0deg) scale(1);
   }
   33% {
-    border-radius: 44% 56% 62% 38% / 41% 58% 42% 59%;
     transform: translate3d(calc(var(--shift) * 14px + 6%), -7%, 0) rotate(52deg) scale(1.12);
   }
   66% {
-    border-radius: 63% 37% 39% 61% / 61% 39% 61% 39%;
     transform: translate3d(calc(var(--shift) * 14px - 5%), 5%, 0) rotate(-34deg) scale(0.94);
   }
 }
@@ -595,15 +578,12 @@ body:has([data-smooth-scroll]) {
 @keyframes ico-blob-b {
   0%,
   100% {
-    border-radius: 46% 54% 58% 42% / 57% 43% 57% 43%;
     transform: translate3d(calc(var(--shift) * -18px), 0, 0) rotate(0deg) scale(1.04);
   }
   40% {
-    border-radius: 62% 38% 41% 59% / 39% 62% 38% 61%;
     transform: translate3d(calc(var(--shift) * -18px - 7%), 6%, 0) rotate(-46deg) scale(0.9);
   }
   70% {
-    border-radius: 39% 61% 55% 45% / 52% 51% 49% 48%;
     transform: translate3d(calc(var(--shift) * -18px + 4%), -5%, 0) rotate(38deg) scale(1.14);
   }
 }
@@ -611,15 +591,12 @@ body:has([data-smooth-scroll]) {
 @keyframes ico-blob-c {
   0%,
   100% {
-    border-radius: 52% 48% 43% 57% / 44% 56% 44% 56%;
     transform: translate3d(calc(var(--shift) * 22px), 0, 0) rotate(0deg) scale(0.98);
   }
   45% {
-    border-radius: 60% 40% 57% 43% / 58% 41% 59% 42%;
     transform: translate3d(calc(var(--shift) * 22px + 8%), -6%, 0) rotate(41deg) scale(1.16);
   }
   75% {
-    border-radius: 43% 57% 48% 52% / 50% 47% 53% 50%;
     transform: translate3d(calc(var(--shift) * 22px - 6%), 4%, 0) rotate(-29deg) scale(0.92);
   }
 }
@@ -760,14 +737,39 @@ body:has([data-smooth-scroll]) {
 
 /* Page-level ambient lights behind a card — the slow drift of colour a dark
    macOS desktop has, so a standalone page reads as lit rather than switched
-   off. Shared by /ico and the project pages. */
+   off. Shared by /ico and the project pages.
+
+   Painted as a ramp rather than as a shape under `filter: blur()`. A blur is
+   re-rasterised every time the compositor touches the layer, and arriving here
+   through the card-to-page morph touches it on every frame of the morph: three
+   vmax-sized blurs cost ten of the 440ms transition's frames on WebKit, which
+   is most of what made opening a card judder. A radial ramp is the same
+   softness resolved once, at no per-frame cost.
+
+   The ramp lives on a pseudo-element inset well past the box, because that is
+   what the blur did — spread the light far outside the element it came from.
+   The element keeps its own size, so each light stays placed where it was. */
 .scene-light {
   position: absolute;
-  border-radius: 50%;
-  filter: blur(90px);
   mix-blend-mode: screen;
   pointer-events: none;
   will-change: translate, scale, rotate;
+}
+
+/* Stops are eyeballed against the blur they replace: a broad core, then a long
+   tail that is all but gone before the edge, so no light ends on a seam. */
+.scene-light::after {
+  content: "";
+  position: absolute;
+  inset: -52%;
+  background: radial-gradient(
+    closest-side,
+    currentColor 0%,
+    color-mix(in srgb, currentColor 72%, transparent) 31%,
+    color-mix(in srgb, currentColor 30%, transparent) 59%,
+    color-mix(in srgb, currentColor 7%, transparent) 81%,
+    transparent 100%
+  );
 }
 
 /* Three clocks per light instead of one, and no two of them share a factor, so

--- a/src/app/cv/page.tsx
+++ b/src/app/cv/page.tsx
@@ -10,9 +10,11 @@ export default async function Cv() {
           Same ambient as the project pages, held back a stop — this one is a
           wall of body copy rather than a card, so the light stays at the edges. */}
       <div aria-hidden="true" className="pointer-events-none fixed inset-0 overflow-hidden bg-[#08080b]">
-        <div className="scene-light scene-light-a -top-[26%] -left-[8%] h-[46vmax] w-[64vmax] bg-[#1b3fb5] opacity-[0.16]" />
-        <div className="scene-light scene-light-b top-[22%] -right-[22%] h-[56vmax] w-[44vmax] bg-[#5b2bc9] opacity-[0.13]" />
-        <div className="scene-light scene-light-c -bottom-[30%] left-[10%] h-[40vmax] w-[58vmax] bg-[#0f6f8c] opacity-[0.10]" />
+        {/* The colour is the text colour: the glow is a gradient of
+            `currentColor`, not a fill — see `.scene-light` in app.css. */}
+        <div className="scene-light scene-light-a -top-[26%] -left-[8%] h-[46vmax] w-[64vmax] text-[#1b3fb5] opacity-[0.16]" />
+        <div className="scene-light scene-light-b top-[22%] -right-[22%] h-[56vmax] w-[44vmax] text-[#5b2bc9] opacity-[0.13]" />
+        <div className="scene-light scene-light-c -bottom-[30%] left-[10%] h-[40vmax] w-[58vmax] text-[#0f6f8c] opacity-[0.10]" />
         <div className="scene-grain absolute inset-0 opacity-[0.05]" />
         <div className="absolute inset-0 bg-[radial-gradient(52%_60%_at_50%_50%,rgba(0,0,0,0.86)_0%,transparent_82%)]" />
         <div className="absolute inset-0 bg-[radial-gradient(92%_80%_at_50%_45%,transparent_38%,rgba(0,0,0,0.6)_100%)]" />

--- a/src/app/ico/page.tsx
+++ b/src/app/ico/page.tsx
@@ -76,9 +76,11 @@ export default function Ico() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{__html: JSON.stringify(jsonLd)}} />
 
       <div aria-hidden="true" className="pointer-events-none fixed inset-0 overflow-hidden">
-        <div className="scene-light scene-light-a -top-[18%] left-[6%] size-[52vmax] bg-[#1c4bd8] opacity-[0.22]" />
-        <div className="scene-light scene-light-b top-[34%] -right-[12%] size-[46vmax] bg-[#6a24d6] opacity-[0.18]" />
-        <div className="scene-light -bottom-[22%] left-[24%] size-[44vmax] bg-[#00a389] opacity-[0.14]" />
+        {/* The colour is the text colour: the glow is a gradient of
+            `currentColor`, not a fill — see `.scene-light` in app.css. */}
+        <div className="scene-light scene-light-a -top-[18%] left-[6%] size-[52vmax] text-[#1c4bd8] opacity-[0.22]" />
+        <div className="scene-light scene-light-b top-[34%] -right-[12%] size-[46vmax] text-[#6a24d6] opacity-[0.18]" />
+        <div className="scene-light -bottom-[22%] left-[24%] size-[44vmax] text-[#00a389] opacity-[0.14]" />
         <div className="scene-grain absolute inset-0 opacity-[0.06]" />
         <div className="absolute inset-0 bg-[radial-gradient(70%_60%_at_50%_45%,transparent_0%,rgba(0,0,0,0.72)_100%)]" />
       </div>

--- a/src/components/card-shot-modal.tsx
+++ b/src/components/card-shot-modal.tsx
@@ -58,7 +58,6 @@ export const CardShotModal: FC<CardShotModalProps> = ({
     isOpen={isOpen}
     instant={instant}
     onClose={onClose}
-    transitionName={Config.viewTransition.card}
     // In the viewport's corner rather than the artwork's, the same place the CV
     // puts it — and on a phone, beside the close button at the bottom of the
     // screen. Goes through `overlay` because the card is transformed and would

--- a/src/components/ico-card.tsx
+++ b/src/components/ico-card.tsx
@@ -101,9 +101,12 @@ const Waves = () => (
 /** Light pooling on the plate — steel greys, so nothing tints the black. */
 const Blobs = () => (
   <div aria-hidden="true" className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]">
-    <div className="ico-blob ico-blob-a absolute -top-[30%] -left-[16%] size-[74%] bg-[#8f9dae]" />
-    <div className="ico-blob ico-blob-b absolute top-[18%] -right-[20%] size-[70%] bg-[#5d6673]" />
-    <div className="ico-blob ico-blob-c absolute -bottom-[34%] left-[22%] size-[64%] bg-[#454a52]" />
+    {/* Sized for the spread the blur used to add, and coloured through `color`
+        rather than `background`: the pool is a gradient of `currentColor` —
+        see `.ico-blob` in app.css. Each one keeps the centre it had. */}
+    <div className="ico-blob ico-blob-a absolute -top-[40%] -left-[26%] size-[94%] text-[#8f9dae]" />
+    <div className="ico-blob ico-blob-b absolute top-[8%] -right-[30%] size-[90%] text-[#5d6673]" />
+    <div className="ico-blob ico-blob-c absolute -bottom-[43%] left-[13%] size-[82%] text-[#454a52]" />
   </div>
 )
 
@@ -315,7 +318,7 @@ export const IcoCard: FC = () => {
           <div className="relative aspect-[1.5858] w-full rounded-3xl" style={{transformStyle: 'preserve-3d'}}>
             <div
               aria-hidden="true"
-              className="ico-halo absolute -inset-8 -z-10"
+              className="ico-halo absolute -inset-20 -z-10"
               style={{transform: 'translateZ(-80px)'}}
             />
 

--- a/src/components/modal.tsx
+++ b/src/components/modal.tsx
@@ -17,8 +17,6 @@ export type ModalProps = {
   children: ReactNode
   onClose(): void
   variant?: ModalVariant
-  /** Marks the card as a shared element, so it can morph into a page of its own. */
-  transitionName?: string
   /** Opens at rest, no enter animation — for a modal restored rather than opened. */
   instant?: boolean
   /**
@@ -41,15 +39,7 @@ const modalVariants: Record<ModalVariant, string> = {
 // and the modal is missing from the snapshot, and the morph back out of a
 // project page has nothing to land on. Closing needs no such latch either —
 // `onClose` only fires once the exit animation is done.
-export const Modal: FC<ModalProps> = ({
-  isOpen,
-  onClose,
-  children,
-  variant = 'small',
-  transitionName,
-  instant,
-  overlay,
-}) => {
+export const Modal: FC<ModalProps> = ({isOpen, onClose, children, variant = 'small', instant, overlay}) => {
   const cardRef = useRef<HTMLDivElement>(null)
   const backdropRef = useRef<HTMLDivElement>(null)
   const closeButtonRef = useRef<HTMLDivElement>(null)
@@ -164,10 +154,7 @@ export const Modal: FC<ModalProps> = ({
           )}
           onClick={e => e.stopPropagation()}
         >
-          <div
-            className="relative card-modal overflow-hidden rounded-[44px] md:rounded-[52px]"
-            style={{viewTransitionName: transitionName}}
-          >
+          <div className="relative card-modal overflow-hidden rounded-[44px] md:rounded-[52px]">
             <div className="relative z-20">{children}</div>
           </div>
         </div>

--- a/src/components/shot-detail.tsx
+++ b/src/components/shot-detail.tsx
@@ -34,51 +34,39 @@ const ShotProperty: FC<EntryShotProperty> = ({name, value, url}) => (
 )
 
 export const ShotDetail: FC<ShotDetailProps> = ({properties, title, description, image, videos, size}) => (
-  // The card and its artwork carry the same view-transition names as the modal
-  // on `/`, so opening a shot expands into this page instead of cutting to it.
+  // No card here, the way the CV has none: on its own page the shot is the page,
+  // and a pane of glass around it only draws a second frame inside the first.
+  // The artwork keeps its view-transition name, so opening a shot still carries
+  // the picture across from the grid rather than cutting to it — what dissolves
+  // is the card that was holding it.
   <div className="flex flex-col w-full">
     <div
-      className="relative card-modal overflow-hidden rounded-[44px] md:rounded-[52px]"
-      style={{viewTransitionName: Config.viewTransition.card}}
+      className="relative w-full h-[250px] md:h-[336px] rounded-[28px] md:rounded-[20px] flex justify-center items-center overflow-hidden border-[0.75px] border-[#FFFFFF26]"
+      style={{viewTransitionName: Config.viewTransition.media}}
     >
-      <div className="relative z-20">
-        <div className="px-[20px] md:px-8 pt-[20px] md:pt-8 pb-2">
-          <div
-            className="relative w-full h-[250px] md:h-[336px] rounded-[28px] md:rounded-[20px] flex justify-center items-center overflow-hidden border-[0.75px] border-[#FFFFFF26]"
-            style={{viewTransitionName: Config.viewTransition.media}}
-          >
-            <Image
-              src={image}
-              alt="shot"
-              fill
-              sizes={size === 'small' ? '289px' : '594px'}
-              style={{objectFit: 'cover'}}
-            />
-            {videos && (
-              <div className="absolute inset-0 overflow-hidden">
-                <LoopVideo srcMp4={videos.mp4} srcWebm={videos.webm} poster={image} />
-              </div>
-            )}
-          </div>
-          <div>
-            <div>
-              <h2 className="text-[16px] font-normal tracking-normal align-middle mt-[40px] text-white leading-[100%]">
-                {title}
-              </h2>
-              <p className="text-[15px] md:text-[16px] font-normal tracking-normal align-middle mt-[8px] mb-[24px] text-white/50 leading-[20px]">
-                {description}
-              </p>
-            </div>
-            <div>
-              {properties.map((item, index) => (
-                <div key={item.name}>
-                  <ShotProperty {...item} />
-                  {properties.length - 1 > index && <div className="h-[1px] w-full bg-white/15" />}
-                </div>
-              ))}
-            </div>
-          </div>
+      <Image src={image} alt="shot" fill sizes={size === 'small' ? '289px' : '594px'} style={{objectFit: 'cover'}} />
+      {videos && (
+        <div className="absolute inset-0 overflow-hidden">
+          <LoopVideo srcMp4={videos.mp4} srcWebm={videos.webm} poster={image} />
         </div>
+      )}
+    </div>
+    <div>
+      <div>
+        <h2 className="text-[16px] font-normal tracking-normal align-middle mt-[40px] text-white leading-[100%]">
+          {title}
+        </h2>
+        <p className="text-[15px] md:text-[16px] font-normal tracking-normal align-middle mt-[8px] mb-[24px] text-white/50 leading-[20px]">
+          {description}
+        </p>
+      </div>
+      <div>
+        {properties.map((item, index) => (
+          <div key={item.name}>
+            <ShotProperty {...item} />
+            {properties.length - 1 > index && <div className="h-[1px] w-full bg-white/15" />}
+          </div>
+        ))}
       </div>
     </div>
   </div>

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -36,13 +36,13 @@ export const Config = {
   // detail page. Both sides must agree, and only one shot can be open at a
   // time, so plain constants are enough — names have to be unique per document.
   viewTransition: {
-    card: 'shot-card',
+    // The artwork, which is the one thing both sides render: the page wears no
+    // card, so there is no card to morph — that one cross-fades with the root.
     media: 'shot-media',
     // The expand/collapse control, shared by the shots and the CV, named in two
-    // parts. The pill needs a name of its own or the artwork covers it: groups
-    // paint in the order their elements do, and inside the card snapshot the
-    // pill sits under `media`. The glyph needs a third name so the two arrow
-    // sets can hand over instead of dissolving through each other.
+    // parts. The pill is named so it rides over the morph rather than fading
+    // with everything else around it, and the glyph takes a name of its own so
+    // the two arrow sets can hand over instead of dissolving through each other.
     toggle: 'card-toggle',
     toggleIcon: 'card-toggle-icon',
   },


### PR DESCRIPTION
Opening a card juddered on Safari, desktop as well as iOS. The cost was the three ambient lights every standalone page sits on: a solid shape under filter: blur(90px). A filtered layer is re-rasterised every time the compositor touches it, and mid-morph it is touched on every frame — ten to twelve of the 440ms transition's frames went to redrawing a glow that never changes. Measured in WebKit on a production build: 91 frames in two seconds with 12 of them dropped, against 111 and one with the blur gone. Nothing else moved the number — not the blend mode, not the layer promotion, not the blur rebuilt on the transition group.

A blur is only softness, and softness is what a gradient is made of. So the lights are ramps now, carried on a pseudo-element inset past the box because spreading light beyond its source is the other half of what the blur was doing. Same on /ico, where the halo and the light pooling on the plate were paying the same toll on every frame the card tilts.

- .scene-light, .ico-halo and .ico-blob draw ramps; colour arrives through `color`, so each light keeps its own hue.
- The blobs' morphing border-radius goes with their blur. It was never legible under 46px of it, and animating a radius repaints the layer.
- /[slug] loses its card, the way the CV has none: on its own page the shot is the page, and glass around it only draws a second frame inside the first. The artwork still carries across; what dissolves is the card that was holding it.