### PR TITLE
fix: Carry the artwork over the card it is leaving

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -92,9 +92,17 @@ export default async function SlugPage({params}: Props) {
       <CardCollapseLink />
       {/* Laid out like the CV: one column on the ambient, started below the top
           edge rather than centred in the screen, so a long shot and a short one
-          both begin in the same place. */}
-      <div className="relative flex min-h-full w-full justify-center px-5 pt-[116px]">
-        <div className="flex w-full max-w-[512px] flex-col">
+          both begin in the same place.
+
+          The column is the open card's box down to the padding — same 12px
+          margin, same 512 cap, same inset — because the artwork inside it is a
+          shared element. A shared element that changes size mid-flight is drawn
+          `cover` at both ends, so the two sides show the same photograph at two
+          different crops and it reads as the picture doubling and sliding into
+          itself. Matched boxes leave the morph nothing to do but carry the
+          picture across. */}
+      <div className="relative flex min-h-full w-full justify-center px-3 pt-[116px] md:px-0">
+        <div className="flex w-full max-w-[512px] flex-col px-[20px] md:px-8">
           <ShotDetail
             title={entry.title}
             image={entry.image}

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -314,6 +314,27 @@ html[data-view-transition]::view-transition-group(modal-surface) {
   }
 }
 
+/* Groups paint in the order they were captured, and that order is not the same
+   in both directions: coming back, the artwork is captured from the page while
+   the card is only captured from the modal that follows it, so the card lands
+   on top and its 136px of frost flattens the picture to grey for the length of
+   the morph. Going in the two are captured together and fall the right way
+   round, which is why it only ever showed on the way back. Stacked by hand, so
+   the order is the same whichever way you are heading: the card is a surface,
+   and everything the card carries sits on it. */
+html[data-view-transition]::view-transition-group(modal-surface) {
+  z-index: 1;
+}
+
+html[data-view-transition]::view-transition-group(shot-media) {
+  z-index: 2;
+}
+
+html[data-view-transition]::view-transition-group(card-toggle),
+html[data-view-transition]::view-transition-group(card-toggle-icon) {
+  z-index: 3;
+}
+
 /* The group carries the fade, for the frost and for what is printed on it
    alike — a second fade on the snapshot would only double it up. */
 html[data-view-transition]::view-transition-old(modal-surface),


### PR DESCRIPTION
Coming back to the grid, the picture washed out to flat grey halfway through the morph and only returned once it was over. Two causes, both asymmetric — which is why it only ever showed on the way back.

## Paint order

View-transition groups paint in the order they were captured, and coming back that order is reversed: `shot-media` is captured from the page, `modal-surface` only from the modal that follows it. So the card landed on top of the artwork and its `backdrop-filter: blur(136px)` flattened the photograph to grey. Going in, both are captured from the same page and fall the right way round.

Stacked explicitly now — surface, then what the surface carries, then the controls.

## Size

The artwork was 512 wide on the page and 448 in the card, so the group resized mid-flight. A snapshot that resizes is drawn `cover` at both ends, which means the two sides showed the same photograph at two different crops, dissolving through each other.

The page column is the card's box now — same 12px margin, same 512 cap, same 20/32px inset. Measured from 393 to 1440: identical width, height and left edge on both sides, only `top` differs, so the morph is a pure glide.

## Checks

Recorded the transition at 25fps and stepped through it, desktop and mobile, both directions: the artwork stays sharp from the first frame to the last. Frame rate unchanged — 107 frames in two seconds, the two dropped being the DOM swap noted in #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)