### PR TITLE
feat: Give every case study its own preview and its own address

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/react-dom": "^19",
     "patch-package": "^8.0.1",
     "postinstall-postinstall": "^2.1.0",
+    "sharp": "^0.34.4",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
     "typescript": "^5"

--- a/src/app/[slug]/opengraph-image.tsx
+++ b/src/app/[slug]/opengraph-image.tsx
@@ -1,0 +1,110 @@
+import {readFile} from 'node:fs/promises'
+import path from 'node:path'
+
+import {ImageResponse} from 'next/og'
+// The renderer reads PNG and JPEG and nothing else, and a third of the shots are
+// WebP — so every one of them is decoded here first. Declared in this project's
+// own devDependencies rather than leant on through Next's optional one, on the
+// same range, so the lockfile already covers it.
+import sharp from 'sharp'
+
+import {entries, getEntryBySlug} from '@/db'
+
+export const size = {height: 630, width: 1200}
+export const contentType = 'image/png'
+
+// 4:3, the ratio every shot is shot at, as tall as the card can be and still
+// keep air above and below it.
+const FRAME = {height: 546, width: 728}
+
+export function generateStaticParams() {
+  return entries.filter(entry => entry.variant === 'shot').map(entry => ({slug: entry.slug}))
+}
+
+type Props = {
+  params: Promise<{slug: string}>
+}
+
+/**
+ * Only here for the alt text, which has to name the shot it is showing and so
+ * cannot be the one static string the `alt` export would allow.
+ */
+export async function generateImageMetadata({params}: Props) {
+  const {slug} = await params
+  const entry = getEntryBySlug(slug)
+
+  return [
+    {
+      alt: entry && entry.variant === 'shot' ? `${entry.title} — case study` : 'Case study',
+      contentType,
+      id: 'og',
+      size,
+    },
+  ]
+}
+
+/**
+ * The shot's own artwork, laid on the ambient the site is lit by.
+ *
+ * The photography is 4:3 and a social card is 1.91:1, so handing the file over
+ * as the preview would have every platform crop the phone's head and feet off.
+ * Held inside the frame instead, on the same dark the pages sit on, so the
+ * picture arrives whole and the card reads as part of the site.
+ *
+ * No type is drawn here on purpose: the title and the description travel as
+ * `og:title` and `og:description`, which every platform sets in its own UI
+ * beneath the image — printing them again would only say it twice, and it keeps
+ * the renderer off fonts it would have to fetch at build time.
+ */
+export default async function OpengraphImage({params}: Props) {
+  const {slug} = await params
+  const entry = getEntryBySlug(slug)
+
+  if (!entry || entry.variant !== 'shot') {
+    return new ImageResponse(<div style={{background: '#08080b', height: '100%', width: '100%'}} />, size)
+  }
+
+  // Resized to the box it lands in as well as re-encoded: the sources are
+  // 1600 wide and the frame is 728, and carrying four times the pixels through
+  // a base64 string only to throw them away costs the build time and nothing
+  // else.
+  const file = await readFile(path.join(process.cwd(), 'public', entry.image))
+  const frame = await sharp(file).resize(FRAME.width, FRAME.height, {fit: 'cover'}).jpeg({quality: 88}).toBuffer()
+  const artwork = `data:image/jpeg;base64,${frame.toString('base64')}`
+
+  return new ImageResponse(
+    <div
+      style={{
+        alignItems: 'center',
+        backgroundColor: '#08080b',
+        // The three lights the pages carry, flattened to the one pose a still
+        // can hold.
+        backgroundImage: [
+          'radial-gradient(46% 58% at 14% 6%, rgba(27, 63, 181, 0.34) 0%, rgba(27, 63, 181, 0) 100%)',
+          'radial-gradient(42% 62% at 92% 34%, rgba(91, 43, 201, 0.28) 0%, rgba(91, 43, 201, 0) 100%)',
+          'radial-gradient(48% 54% at 40% 108%, rgba(15, 111, 140, 0.22) 0%, rgba(15, 111, 140, 0) 100%)',
+        ].join(', '),
+        display: 'flex',
+        height: '100%',
+        justifyContent: 'center',
+        width: '100%',
+      }}
+    >
+      {/* 4:3 at this height, so the frame is the picture rather than a box
+          around it — same corner and same hairline the artwork wears on the
+          page it came from. */}
+      <img
+        src={artwork}
+        alt=""
+        width={FRAME.width}
+        height={FRAME.height}
+        style={{
+          border: '1px solid rgba(255, 255, 255, 0.15)',
+          borderRadius: 28,
+          objectFit: 'cover',
+        }}
+      />
+    </div>,
+    size
+  )
+}

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -30,26 +30,29 @@ export async function generateMetadata({params}: Props): Promise<Metadata> {
   const description = entry.description.slice(0, 160) + (entry.description.length > 160 ? '...' : '')
 
   return {
+    // Without this every case study inherits the root's `/`, which tells a
+    // crawler that all thirty-odd of them are the same page as the home page.
+    alternates: {
+      canonical: `/${slug}`,
+    },
     description,
     keywords: [entry.title, productName, ...entry.properties.map(p => p.value), 'mobile development', 'case study'],
     openGraph: {
       description,
-      images: [
-        {
-          alt: entry.title,
-          height: entry.size === 'small' ? 289 : 594,
-          url: entry.image,
-          width: entry.size === 'small' ? 289 : 594,
-        },
-      ],
+      // `og:image` comes from `opengraph-image.tsx` beside this file: the
+      // shot's own artwork, laid out for the 1.91:1 a social card crops to.
+      // Naming the source file here instead would hand every platform a 4:3
+      // photograph to cut a strip out of.
+      locale: 'en_US',
+      siteName: 'Jan Blazej Portfolio',
       title: entry.title,
       type: 'article',
+      url: `/${slug}`,
     },
     title: entry.title,
     twitter: {
       card: 'summary_large_image',
       description,
-      images: [entry.image],
       title: entry.title,
     },
   }

--- a/src/app/cv/page.tsx
+++ b/src/app/cv/page.tsx
@@ -1,4 +1,56 @@
+import type {Metadata} from 'next'
+
 import {CardCollapseLink, CV, PersonJsonLd, SmoothScroll} from '@/components'
+
+const description =
+  'The full CV of Jan Blazej — work experience, side projects and education. Lead Mobile Developer specialising in React Native, Expo and TypeScript, based in Prague, Czechia.'
+
+/**
+ * Declared rather than inherited. Without this the page took the root's, which
+ * pointed its canonical at `/` — telling a crawler the CV is the home page —
+ * and gave a shared link the site's title and blurb instead of its own.
+ *
+ * The preview is the portfolio's, on purpose: the CV is a wall of body copy,
+ * with nothing in it that survives being shrunk to a card.
+ */
+export const metadata: Metadata = {
+  alternates: {
+    canonical: '/cv',
+  },
+  description,
+  keywords: [
+    'Jan Blazej CV',
+    'Jan Blazej resume',
+    'Lead Mobile Developer CV',
+    'React Native Developer CV',
+    'Expo',
+    'TypeScript',
+    'Prague',
+  ],
+  openGraph: {
+    description,
+    images: [
+      {
+        alt: 'Jan Blazej - Lead Mobile Developer',
+        height: 630,
+        url: '/png/og-image.png',
+        width: 1200,
+      },
+    ],
+    locale: 'en_US',
+    siteName: 'Jan Blazej Portfolio',
+    title: 'CV — Jan Blazej',
+    type: 'profile',
+    url: '/cv',
+  },
+  title: 'CV',
+  twitter: {
+    card: 'summary_large_image',
+    description,
+    images: ['/png/og-image.png'],
+    title: 'CV — Jan Blazej',
+  },
+}
 
 export default async function Cv() {
   return (

--- a/src/app/ico/page.tsx
+++ b/src/app/ico/page.tsx
@@ -1,6 +1,7 @@
 import type {Metadata} from 'next'
 
 import {IcoCard, PageCloseLink} from '@/components'
+import {Config} from '@/config'
 import {ico} from '@/db'
 
 /**
@@ -44,7 +45,7 @@ export const metadata: Metadata = {
     description: `Business details — IČO ${ico.ico}, ${ico.location}.`,
     images: [ogImage],
     title: `IČO ${ico.ico} · ${ico.name}`,
-    url: 'https://janblazej.dev/ico',
+    url: `${Config.site}/ico`,
   },
   title: 'IČO & Business Details',
   twitter: {
@@ -71,7 +72,7 @@ const jsonLd = {
     value: ico.ico,
   },
   name: ico.name,
-  url: 'https://janblazej.dev/ico',
+  url: `${Config.site}/ico`,
 }
 
 export default function Ico() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import type {Metadata, Viewport} from 'next'
 import {type ReactNode} from 'react'
 
 import {GoogleAnalytics, WebVitals} from '@/components'
+import {Config} from '@/config'
 // Imported straight from the module rather than `@/providers`: the barrel would
 // pull the camera and sound providers into every route's client bundle.
 import {NavigationProvider} from '@/providers/NavigationProvider'
@@ -28,7 +29,7 @@ export const metadata: Metadata = {
   appleWebApp: {
     statusBarStyle: 'black-translucent',
   },
-  authors: [{name: 'Jan Blazej', url: 'https://janblazej.dev'}],
+  authors: [{name: 'Jan Blazej', url: Config.site}],
   creator: 'Jan Blazej',
   description:
     'Experienced Lead Mobile Developer specializing in React Native, Expo, and TypeScript. Building high-performance mobile applications for iOS and Android. Based in Prague, Czechia.',
@@ -56,7 +57,7 @@ export const metadata: Metadata = {
     'RealityKit',
   ],
   manifest: '/site.webmanifest',
-  metadataBase: new URL('https://janblazej.dev'),
+  metadataBase: new URL(Config.site),
   openGraph: {
     description:
       'Experienced Lead Mobile Developer specializing in React Native, Expo, and TypeScript. Building high-performance mobile applications for iOS and Android.',
@@ -72,7 +73,7 @@ export const metadata: Metadata = {
     siteName: 'Jan Blazej Portfolio',
     title: 'Jan Blazej - Lead Mobile Developer & Founder',
     type: 'website',
-    url: 'https://janblazej.dev',
+    url: Config.site,
   },
   publisher: 'Jan Blazej',
   robots: {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,3 +1,5 @@
+import {Config} from '@/config'
+
 export default function robots() {
   return {
     rules: [
@@ -7,6 +9,6 @@ export default function robots() {
         userAgent: '*',
       },
     ],
-    sitemap: 'https://janblazej.dev/sitemap.xml',
+    sitemap: `${Config.site}/sitemap.xml`,
   }
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,8 @@
+import {Config} from '@/config'
 import {entries} from '@/db'
 
 export default function sitemap() {
-  const baseUrl = 'https://janblazej.dev'
+  const baseUrl = Config.site
 
   const routes = [
     {

--- a/src/components/person-json-ld.tsx
+++ b/src/components/person-json-ld.tsx
@@ -1,3 +1,5 @@
+import {Config} from '@/config'
+
 const jsonLd = {
   '@context': 'https://schema.org',
   '@type': 'Person',
@@ -7,7 +9,7 @@ const jsonLd = {
     addressLocality: 'Prague',
   },
   email: 'hello@janblazej.dev',
-  image: 'https://janblazej.dev/png/profile@3x.png',
+  image: `${Config.site}/png/profile@3x.png`,
   jobTitle: 'Lead Mobile Developer & Founder',
   knowsAbout: [
     'React Native',
@@ -22,7 +24,7 @@ const jsonLd = {
   ],
   name: 'Jan Blazej',
   sameAs: ['https://www.linkedin.com/in/hzblj', 'https://github.com/hzblj', 'https://www.instagram.com/hzblj'],
-  url: 'https://janblazej.dev',
+  url: Config.site,
   worksFor: {
     '@type': 'Organization',
     name: 'Footshop',

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -28,6 +28,11 @@ export const Config = {
     mapUrl: 'https://maps.app.goo.gl/7TbuX47ttiZbRms27',
   },
   origin: {x: -188, y: -172},
+  // The host every absolute URL the site publishes has to carry — canonicals,
+  // `og:` tags, the sitemap, the structured data. The apex redirects here, so
+  // anything naming it sends a crawler one hop short of where it meant to point,
+  // and a canonical that redirects is a canonical arguing with itself.
+  site: 'https://www.janblazej.dev',
   viewport: {
     height: 1638,
     width: 2448,


### PR DESCRIPTION
Three things the site was telling crawlers wrongly, plus the domain.

## Canonicals

Every case study inherited the root's `alternates.canonical: '/'` — thirty-two pages all claiming to be the home page. They name themselves now and carry `og:url` and `og:site_name` with it.

## Previews

The preview was the artwork file itself, declared as 594 square when the photography is 1600×1200. So every platform got a 4:3 photograph to crop a 1.91:1 strip out of — through the middle of the phone — and was told the wrong dimensions while doing it.

`src/app/[slug]/opengraph-image.tsx` renders a card per shot instead: the artwork whole, on the ambient the pages are lit by, at 1200×630. Generated from the entry at build time, so a new shot brings its own preview and none of them can go stale the way `/ico`'s did.

`sharp` does the decoding — ten of the thirty-two shots are WebP, which the renderer cannot read. Added to devDependencies on the same range Next already uses for it, so the existing lockfile entry covers it and no install is needed.

## The CV

Had no metadata at all, so it inherited the root's — including the canonical pointing at `/`. It has its own title, description and canonical now, and keeps the portfolio's preview image on purpose: it is a wall of body copy with nothing in it that survives being shrunk to a thumbnail.

## The domain

`janblazej.dev` 308s to `www.janblazej.dev`, but every absolute URL the site published named the apex — canonicals, `og:` tags, sitemap, `robots.txt`, structured data. All one redirect short of where they meant to point. Now one constant in `Config`.

## Checks

Built and served: 35 sitemap URLs, zero non-www left anywhere, canonicals and `og:url` per page, `og:image` resolving to a 1200×630 PNG for both JPEG- and WebP-sourced shots, per-shot `og:image:alt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)